### PR TITLE
Updates to medium button defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Changed the medium size button (Filled, Tonal, Outlined and Text buttons) text style token from “body-large”→“label-large”. (Figma 2025, May 13)
+
+- Changed the medium size (Filled, Tonal, Outlined and Text) button leading and trailing icon (+loader) sizes from 24px→20px. (Figma 2025, May 13)
+
 - Changed the way the minimum sizes are handled for buttons. Button size is determined mainly by the contents. But this does not always give the same result as in Figma. So buttons also have minimum width and height values defined. This way the button will not resize when changing to loading mode and back. As in the primary case you want to change minimums for all the buttons in one go, then the values are now attached to `LabTheme.constants` and can be easily overridden for the whole when defining the app theme:
 
   ```kotlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Changed the way the minimum sizes are handled for buttons. Button size is determined mainly by the contents. But as this does not always give the same result as in Figma. So Buttons also have minimum width and height values defined. This way the button will not resize when changing to loading mode and back. As in the primary case you want to change minimums for all the buttons in one go, then the values are now attached to `LabTheme.constants` and can be easily overridden for the whole when defining the app theme:
+- Changed the way the minimum sizes are handled for buttons. Button size is determined mainly by the contents. But this does not always give the same result as in Figma. So buttons also have minimum width and height values defined. This way the button will not resize when changing to loading mode and back. As in the primary case you want to change minimums for all the buttons in one go, then the values are now attached to `LabTheme.constants` and can be easily overridden for the whole when defining the app theme:
 
   ```kotlin
   @Composable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,48 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project does not use semantic versioning.
 
-## 0.0.7 - [UNRELEASED]
+## 0.0.8 - [UNRELEASED]
 
 ### Changed
 
 - ..
+
+## 0.0.7 - 2025.05.16
+
+### Changed
+
+- Changed the way the minimum sizes are handled for buttons. Button size is determined mainly by the contents. But as this does not always give the same result as in Figma. So Buttons also have minimum width and height values defined. This way the button will not resize when changing to loading mode and back. As in the primary case you want to change minimums for all the buttons in one go, then the values are now attached to `LabTheme.constants` and can be easily overridden for the whole when defining the app theme:
+
+  ```kotlin
+  @Composable
+  fun AppTheme(
+      content: @Composable () -> Unit,
+  ) {
+      LabTheme(
+          typography = LabThemeDefaults.typography(fontFamily = defaultFontFamily()),
+          content = content,
+          constants = LabThemeDefaults.constants(buttonMediumMinHeight = 48.dp)
+      )
+  }
+  ```
+
+  Alternatively, the `CompositionLocalProvider` can also be used to override these for specific button instances:
+
+  ```kotlin
+  val constantsOverride = LabThemeDefaults.constants(
+      buttonMediumMinHeight = 60.dp,
+      buttonSmallMinHeight = 28.dp,
+  )
+  // Use the CompositionLocalProvider to provide a different set of LocalLabConstants for this composable
+  CompositionLocalProvider(LocalLabConstants provides constantsOverride) {
+      LabFilledButton(
+          text = "Click!",
+          onClick = {},
+      )
+  }
+  ```
+
+  
 
 ## 0.0.6 -2025.05.13
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mobi Lab Components for Compose (`LabComponentsCompose`) help developers execute
 Maven Central artifact available from https://central.sonatype.com/search?q=mobi.lab.labcomponents:labcomponents-compose
 
 ```groovy
-implementation 'mobi.lab.labcomponents:labcomponents-compose:0.0.6'
+implementation 'mobi.lab.labcomponents:labcomponents-compose:0.0.7'
 ```
 
 The components provide implementations for [Mobi Lab's design system](https://www.figma.com/file/gxt4iyWGyliILJSOCLXonl/P42-design-system-template?type=design&node-id=1652-14713&mode=design&t=j4TbnOpahS3korsT-0). These components are based on [Material Components for Android](https://github.com/material-components/material-components-android).
@@ -16,6 +16,7 @@ The components provide implementations for [Mobi Lab's design system](https://ww
 
 | Lab Components for Compose version | Compose BOM version used | CompileSdk used     |
 | ---------------------------------- | :----------------------- | ------------------- |
+| 0.0.7                              | 2025.05.00               | API 36 / Android 16 |
 | 0.0.6                              | 2025.05.00               | API 36 / Android 16 |
 | 0.0.5                              | 2025.05.00               | API 36 / Android 16 |
 | 0.0.4                              | 2025.04.01               | API 36 / Android 16 |

--- a/app-demo/src/main/java/mobi/lab/components/compose/demo/AppTheme.kt
+++ b/app-demo/src/main/java/mobi/lab/components/compose/demo/AppTheme.kt
@@ -13,7 +13,7 @@ fun AppTheme(
 ) {
     LabTheme(
         typography = LabThemeDefaults.typography(fontFamily = defaultFontFamily()),
-        content = content
+        content = content,
     )
 }
 

--- a/app-demo/src/main/java/mobi/lab/components/compose/demo/button/ButtonDestination.kt
+++ b/app-demo/src/main/java/mobi/lab/components/compose/demo/button/ButtonDestination.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -34,6 +35,8 @@ import mobi.lab.components.compose.demo.R
 import mobi.lab.components.compose.demo.common.LabelSwitch
 import mobi.lab.components.compose.demo.common.LightDarkModeMenu
 import mobi.lab.components.compose.theme.LabTheme
+import mobi.lab.components.compose.theme.LabThemeDefaults
+import mobi.lab.components.compose.theme.LocalLabConstants
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.limitMaxContentWidth
 import mobi.lab.components.compose.util.withAlpha
@@ -605,82 +608,69 @@ private fun CustomTextStyleButtons(enabled: MutableState<Boolean>) {
 private fun CustomMinSizeButtons(enabled: MutableState<Boolean>) {
     SectionTitle(stringResource(R.string.text_customization_custom_min_size))
     val customTextStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
-/*    LabFilledButton(
-        text = stringResource(R.string.label_filled),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 60.dp,
-        minHeight = 60.dp,
+    val constantsOverride = LabThemeDefaults.constants(
+        buttonMediumMinHeight = 60.dp,
+        buttonSmallMinHeight = 28.dp,
     )
-    LabFilledSmallButton(
-        text = stringResource(R.string.label_filled),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 28.dp,
-        minHeight = 28.dp,
-        textStyle = customTextStyle,
-    )
-    LabTonedButton(
-        text = stringResource(R.string.label_toned),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 60.dp,
-        minHeight = 60.dp,
-    )
-    LabTonedSmallButton(
-        text = stringResource(R.string.label_toned),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 28.dp,
-        minHeight = 28.dp,
-        textStyle = customTextStyle,
-    )
-    LabOutlinedButton(
-        text = stringResource(R.string.label_outlined),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 60.dp,
-        minHeight = 60.dp,
-    )
-    LabOutlinedSmallButton(
-        text = stringResource(R.string.label_outlined),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 28.dp,
-        minHeight = 28.dp,
-        textStyle = customTextStyle,
-    )
-    LabTextButton(
-        text = stringResource(R.string.label_text),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 60.dp,
-        minHeight = 60.dp,
-    )
-    LabTextSmallButton(
-        text = stringResource(R.string.label_text_small),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 28.dp,
-        minHeight = 28.dp,
-        textStyle = customTextStyle,
-    )
-    LabIconButton(
-        icon = ImageSource.fromRes(R.drawable.ic_placeholder16),
-        contentDescription = stringResource(R.string.text_button_with_a_placeholder_icon),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 60.dp,
-        minHeight = 60.dp,
-    )
-    LabIconSmallButton(
-        icon = ImageSource.fromRes(R.drawable.ic_placeholder16),
-        contentDescription = stringResource(R.string.text_button_with_a_placeholder_icon),
-        onClick = {},
-        enabled = enabled.value,
-        minWidth = 28.dp,
-        minHeight = 28.dp,
-    )*/
+    // Use the CompositionLocalProvider to provide a different set of LocalLabConstants for this composable
+    CompositionLocalProvider(LocalLabConstants provides constantsOverride) {
+        LabFilledButton(
+            text = stringResource(R.string.label_filled),
+            onClick = {},
+            enabled = enabled.value,
+        )
+        LabFilledSmallButton(
+            text = stringResource(R.string.label_filled),
+            onClick = {},
+            enabled = enabled.value,
+            textStyle = customTextStyle,
+        )
+        LabTonedButton(
+            text = stringResource(R.string.label_toned),
+            onClick = {},
+            enabled = enabled.value,
+        )
+        LabTonedSmallButton(
+            text = stringResource(R.string.label_toned),
+            onClick = {},
+            enabled = enabled.value,
+            textStyle = customTextStyle,
+        )
+        LabOutlinedButton(
+            text = stringResource(R.string.label_outlined),
+            onClick = {},
+            enabled = enabled.value,
+        )
+        LabOutlinedSmallButton(
+            text = stringResource(R.string.label_outlined),
+            onClick = {},
+            enabled = enabled.value,
+            textStyle = customTextStyle,
+        )
+        LabTextButton(
+            text = stringResource(R.string.label_text),
+            onClick = {},
+            enabled = enabled.value,
+        )
+        LabTextSmallButton(
+            text = stringResource(R.string.label_text_small),
+            onClick = {},
+            enabled = enabled.value,
+            textStyle = customTextStyle,
+        )
+        LabIconButton(
+            icon = ImageSource.fromRes(R.drawable.ic_placeholder16),
+            contentDescription = stringResource(R.string.text_button_with_a_placeholder_icon),
+            onClick = {},
+            enabled = enabled.value,
+        )
+        LabIconSmallButton(
+            icon = ImageSource.fromRes(R.drawable.ic_placeholder16),
+            contentDescription = stringResource(R.string.text_button_with_a_placeholder_icon),
+            onClick = {},
+            enabled = enabled.value,
+        )
+    }
 }
 
 @Composable

--- a/app-demo/src/main/java/mobi/lab/components/compose/demo/button/ButtonDestination.kt
+++ b/app-demo/src/main/java/mobi/lab/components/compose/demo/button/ButtonDestination.kt
@@ -605,7 +605,7 @@ private fun CustomTextStyleButtons(enabled: MutableState<Boolean>) {
 private fun CustomMinSizeButtons(enabled: MutableState<Boolean>) {
     SectionTitle(stringResource(R.string.text_customization_custom_min_size))
     val customTextStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
-    LabFilledButton(
+/*    LabFilledButton(
         text = stringResource(R.string.label_filled),
         onClick = {},
         enabled = enabled.value,
@@ -680,7 +680,7 @@ private fun CustomMinSizeButtons(enabled: MutableState<Boolean>) {
         enabled = enabled.value,
         minWidth = 28.dp,
         minHeight = 28.dp,
-    )
+    )*/
 }
 
 @Composable

--- a/lib/src/main/java/mobi/lab/components/compose/theme/LabConstants.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/theme/LabConstants.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.unit.Dp
 @Immutable
 public data class LabConstants(
     public val disabledAlpha: Float,
+    /**
+     * Can be used with .limitMaxContentWidth()
+     */
     public val maxContentWidth: Dp,
     public val buttonMediumMinWidth: Dp,
     public val buttonMediumMinHeight: Dp,

--- a/lib/src/main/java/mobi/lab/components/compose/theme/LabConstants.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/theme/LabConstants.kt
@@ -9,5 +9,9 @@ import androidx.compose.ui.unit.Dp
 @Immutable
 public data class LabConstants(
     public val disabledAlpha: Float,
-    public val maxContentWidth: Dp
+    public val maxContentWidth: Dp,
+    public val buttonMediumMinWidth: Dp,
+    public val buttonMediumMinHeight: Dp,
+    public val buttonSmallMinWidth: Dp,
+    public val buttonSmallMinHeight: Dp,
 )

--- a/lib/src/main/java/mobi/lab/components/compose/theme/LabTheme.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/theme/LabTheme.kt
@@ -112,7 +112,7 @@ private val LocalLabDimensions = staticCompositionLocalOf<LabDimensions> {
     error("No LabDimensions provided")
 }
 
-private val LocalLabConstants = staticCompositionLocalOf<LabConstants> {
+internal val LocalLabConstants = staticCompositionLocalOf<LabConstants> {
     error("No LabConstants provided")
 }
 

--- a/lib/src/main/java/mobi/lab/components/compose/theme/LabTheme.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/theme/LabTheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
@@ -100,23 +101,23 @@ internal fun ProvideLabValues(
     )
 }
 
-private val LocalLabColors = staticCompositionLocalOf<LabColors> {
+public val LocalLabColors: ProvidableCompositionLocal<LabColors> = staticCompositionLocalOf {
     error("No LabColors provided")
 }
 
-private val LocalLabTypography = staticCompositionLocalOf<LabTypography> {
+public val LocalLabTypography: ProvidableCompositionLocal<LabTypography> = staticCompositionLocalOf {
     error("No LabTypography provided")
 }
 
-private val LocalLabDimensions = staticCompositionLocalOf<LabDimensions> {
+public val LocalLabDimensions: ProvidableCompositionLocal<LabDimensions> = staticCompositionLocalOf {
     error("No LabDimensions provided")
 }
 
-internal val LocalLabConstants = staticCompositionLocalOf<LabConstants> {
+public val LocalLabConstants: ProvidableCompositionLocal<LabConstants> = staticCompositionLocalOf {
     error("No LabConstants provided")
 }
 
-private val LocalLabShapes = staticCompositionLocalOf<LabShapes> {
+public val LocalLabShapes: ProvidableCompositionLocal<LabShapes> = staticCompositionLocalOf {
     error("No LabShapes provided")
 }
 

--- a/lib/src/main/java/mobi/lab/components/compose/theme/LabThemeDefaults.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/theme/LabThemeDefaults.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.sp
 import mobi.lab.components.compose.theme.tokens.PaletteTokens
 import mobi.lab.components.compose.util.withAlpha
 import mobi.lab.components.compose.util.withFontFamily
+import mobi.lab.components.compose.widget.button.LabButtonDefaults
 
 public object LabThemeDefaults {
 
@@ -24,10 +25,21 @@ public object LabThemeDefaults {
     }
 
     @Composable
-    public fun constants(): LabConstants {
+    public fun constants(
+        disabledAlpha: Float = 0.4f,
+        maxContentWidth: Dp = 500.dp,
+        buttonMediumMinWidth: Dp = LabButtonDefaults.minWidth,
+        buttonMediumMinHeight: Dp = LabButtonDefaults.minHeight,
+        buttonSmallMinWidth: Dp = LabButtonDefaults.smallMinWidth,
+        buttonSmallMinHeight: Dp = LabButtonDefaults.smallMinHeight,
+    ): LabConstants {
         return LabConstants(
-            disabledAlpha = 0.4f,
-            maxContentWidth = 500.dp,
+            disabledAlpha = disabledAlpha,
+            maxContentWidth = maxContentWidth,
+            buttonMediumMinWidth = buttonMediumMinWidth,
+            buttonMediumMinHeight = buttonMediumMinHeight,
+            buttonSmallMinWidth = buttonSmallMinWidth,
+            buttonSmallMinHeight = buttonSmallMinHeight,
         )
     }
 

--- a/lib/src/main/java/mobi/lab/components/compose/theme/LabThemeDefaults.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/theme/LabThemeDefaults.kt
@@ -28,6 +28,8 @@ public object LabThemeDefaults {
     public fun constants(
         disabledAlpha: Float = 0.4f,
         maxContentWidth: Dp = 500.dp,
+        // Note - if we get more of these button specific ones then
+        // probably makes sense to define a button style wrapper.
         buttonMediumMinWidth: Dp = LabButtonDefaults.minWidth,
         buttonMediumMinHeight: Dp = LabButtonDefaults.minHeight,
         buttonSmallMinWidth: Dp = LabButtonDefaults.smallMinWidth,

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButton.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButton.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Surface
@@ -42,8 +41,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mobi.lab.components.compose.theme.LabTheme
+import mobi.lab.components.compose.theme.LabTheme.constants
 import mobi.lab.components.compose.theme.noRippleConfiguration
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.previewInteractionSourceOf
@@ -54,8 +53,6 @@ import mobi.lab.components.compose.widget.image.ImageSource
 @Composable
 public fun LabButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.minWidth,
-    minHeight: Dp = LabButtonDefaults.minHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -65,6 +62,7 @@ public fun LabButton(
     iconSize: Dp = LabButtonDefaults.iconSize,
     iconSpacing: Dp = LabButtonDefaults.iconSpacing,
     showProgress: Boolean = false,
+    progressSize: Dp = LabButtonDefaults.progressSize,
     enabled: Boolean = true,
     textStyle: TextStyle = LabButtonDefaults.textStyle,
     shape: Shape = LabButtonDefaults.shape,
@@ -83,8 +81,8 @@ public fun LabButton(
     LabButton(
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
+        minWidth = constants.buttonMediumMinWidth,
+        minHeight = constants.buttonMediumMinHeight,
         enabled = enabled,
         textStyle = textStyle,
         shape = shape,
@@ -95,8 +93,8 @@ public fun LabButton(
         interactionSource = interactionSource,
     ) {
         LabButtonContent(
-            minHeight = minHeight,
             showProgress = showProgress,
+            progressSize = progressSize,
             iconStart = iconStart,
             iconStartContentDescription = iconStartContentDescription,
             iconSize = iconSize,
@@ -104,7 +102,6 @@ public fun LabButton(
             iconSpacing = iconSpacing,
             iconEnd = iconEnd,
             iconEndContentDescription = iconEndContentDescription,
-            contentPadding = contentPadding,
             indeterminateProgressIndicator = indeterminateProgressIndicator,
         )
     }
@@ -113,8 +110,6 @@ public fun LabButton(
 @Composable
 public fun LabSmallButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.smallMinWidth,
-    minHeight: Dp = LabButtonDefaults.smallMinHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -124,6 +119,7 @@ public fun LabSmallButton(
     iconSize: Dp = LabButtonDefaults.smallIconSize,
     iconSpacing: Dp = LabButtonDefaults.iconSpacing,
     showProgress: Boolean = false,
+    progressSize: Dp = LabButtonDefaults.smallProgressSize,
     enabled: Boolean = true,
     textStyle: TextStyle = LabButtonDefaults.smallTextStyle,
     shape: Shape = LabButtonDefaults.shape,
@@ -142,8 +138,8 @@ public fun LabSmallButton(
     LabButton(
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
+        minWidth = constants.buttonSmallMinWidth,
+        minHeight = constants.buttonSmallMinHeight,
         enabled = enabled,
         textStyle = textStyle,
         shape = shape,
@@ -154,8 +150,8 @@ public fun LabSmallButton(
         interactionSource = interactionSource
     ) {
         LabButtonContent(
-            minHeight = LabButtonDefaults.smallMinHeight,
             showProgress = showProgress,
+            progressSize = progressSize,
             iconStart = iconStart,
             iconStartContentDescription = iconStartContentDescription,
             iconSize = iconSize,
@@ -163,7 +159,6 @@ public fun LabSmallButton(
             iconSpacing = iconSpacing,
             iconEnd = iconEnd,
             iconEndContentDescription = iconEndContentDescription,
-            contentPadding = contentPadding,
             indeterminateProgressIndicator = indeterminateProgressIndicator,
         )
     }
@@ -185,15 +180,11 @@ public fun LabButton(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable RowScope.() -> Unit
 ) {
-    // The small button minHeight / height is 36dp, which is lower than the required touch target of 48dp.
-    // While these rectangular buttons are wider and thus still present a proper touch target,
-    // then the square loading buttons below in the same table are 36dpx36dp and this not valid touch targets in terms
-    // of accessibility.
-    // I will currently suppress this issue in with LocalMinimumInteractiveComponentSize provides 36.dp,
-    // but we should address it.
+    // Note: If the button size is smaller than the required touch target of 48dp x 48dp the
+    // system will apply invisible touchable padding based on LocalMinimumInteractiveComponentSize.
+    // This means buttons will have the normal padding and then the invisible touch area padding also.
     CompositionLocalProvider(
         LocalRippleConfiguration provides noRippleConfiguration(),
-        LocalMinimumInteractiveComponentSize provides 36.dp,
     ) {
         val containerColor = colors.containerColor(enabled, interactionSource)
         val contentColor = colors.contentColor(enabled, interactionSource)
@@ -232,8 +223,8 @@ public fun LabButton(
 
 @Composable
 public fun LabButtonContent(
-    minHeight: Dp = LabButtonDefaults.minHeight,
     showProgress: Boolean = false,
+    progressSize: Dp = LabButtonDefaults.progressSize,
     iconStart: ImageSource? = null,
     iconStartContentDescription: String = "",
     iconSize: Dp = LabButtonDefaults.iconSize,
@@ -241,10 +232,6 @@ public fun LabButtonContent(
     iconSpacing: Dp = LabButtonDefaults.iconSpacing,
     iconEnd: ImageSource? = null,
     iconEndContentDescription: String = "",
-    contentPadding: PaddingValues = LabButtonDefaults.contentPaddings(
-        hasIconStart = iconStart != null,
-        hasIconEnd = iconEnd != null
-    ),
     indeterminateProgressIndicator: @Composable (modifier: Modifier) -> Unit = { mod ->
         DefaultButtonProgressIndicator(mod)
     },
@@ -290,11 +277,8 @@ public fun LabButtonContent(
             }
         }
         if (showProgress) {
-            val height = remember(contentPadding) {
-                minHeight - contentPadding.calculateBottomPadding() - contentPadding.calculateTopPadding()
-            }
             val modifier = Modifier
-                .size(height)
+                .size(progressSize)
                 .align(Alignment.Center)
             indeterminateProgressIndicator.invoke(modifier)
         }
@@ -403,19 +387,6 @@ private fun PreviewLightDifferentFont() {
 
 @Preview(showBackground = true)
 @Composable
-private fun PreviewLightDifferentSize() {
-    PreviewContainer {
-        LabButton(
-            text = "M Size different",
-            onClick = {},
-            minWidth = 60.dp,
-            minHeight = 60.dp,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
 private fun PreviewSmallLightDisabled() {
     PreviewContainer {
         LabSmallButton(
@@ -433,20 +404,6 @@ private fun PreviewSmallLightDifferentFont() {
         LabSmallButton(
             text = "S Font different",
             onClick = {},
-            textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PreviewSmallLightDifferentSize() {
-    PreviewContainer {
-        LabSmallButton(
-            text = "S Size different",
-            onClick = {},
-            minWidth = 28.dp,
-            minHeight = 28.dp,
             textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
         )
     }

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButtonDefaults.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButtonDefaults.kt
@@ -18,9 +18,21 @@ import mobi.lab.components.compose.widget.progress.LabIndeterminateCircularIndic
 @Suppress("LongParameterList")
 @Immutable
 public object LabButtonDefaults {
-
-    public val iconSize: Dp = 24.dp
+    // NOTE: Button size depends on sizes of things inside it - text, paddings, icons, progress.
+    public val iconSize: Dp = 20.dp
     public val smallIconSize: Dp = 16.dp
+
+    // Icon button has larger medium sized button icon
+    public val iconButtonIconSize: Dp = 24.dp
+
+    // But the same size small sized button icon
+    public val iconButtonSmallIconSize: Dp = 16.dp
+
+    // Progress size is set
+    public val progressSize: Dp = 20.dp
+    public val smallProgressSize: Dp = 16.dp
+    public val iconButtonProgressSize: Dp = 24.dp
+    public val iconButtonSmallProgressSize: Dp = 16.dp
 
     // Content padding differs based if there is an icon or not and if it is a medium or small button
     public val contentPaddingNoIcons: PaddingValues = PaddingValues(
@@ -175,7 +187,7 @@ public object LabButtonDefaults {
         }
     }
 
-    public val minWidth: Dp = 48.dp
+    public val minWidth: Dp = 44.dp
     public val minHeight: Dp = 48.dp
     public val smallMinWidth: Dp = 36.dp
     public val smallMinHeight: Dp = 36.dp
@@ -188,7 +200,7 @@ public object LabButtonDefaults {
     public val textStyle: TextStyle @Composable get() = LabTheme.typography.labelLarge.copy(color = Color.Unspecified)
 
     // Text style for small buttons used to be different so we have a separate default here atm
-    public val smallTextStyle: TextStyle @Composable get() = textStyle
+    public val smallTextStyle: TextStyle @Composable get() = LabTheme.typography.labelLarge.copy(color = Color.Unspecified)
 
     @Composable
     public fun buttonBorder(): LabButtonBorder {

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButtonDefaults.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButtonDefaults.kt
@@ -187,8 +187,15 @@ public object LabButtonDefaults {
         }
     }
 
+    // For supporting text in buttons we also define the min size
+    // here. Otherwise the button would resize when it switches between
+    // text only (these do not have predictable sizes) and
+    // icon/progress (these have predictable sizes).
+    // Note that iconButton has 48dp as min height,
+    // but it only contains an icon and progress and
+    // the size is set based on those.
     public val minWidth: Dp = 44.dp
-    public val minHeight: Dp = 48.dp
+    public val minHeight: Dp = 44.dp
     public val smallMinWidth: Dp = 36.dp
     public val smallMinHeight: Dp = 36.dp
     public val iconSpacing: Dp = 8.dp

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButtonDefaults.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabButtonDefaults.kt
@@ -185,10 +185,10 @@ public object LabButtonDefaults {
 
     public val shape: Shape @Composable get() = LabTheme.shapes.button
     public val iconButtonShape: Shape @Composable get() = LabTheme.shapes.button
-    public val textStyle: TextStyle @Composable get() = LabTheme.typography.bodyLarge.copy(color = Color.Unspecified)
+    public val textStyle: TextStyle @Composable get() = LabTheme.typography.labelLarge.copy(color = Color.Unspecified)
 
-    // Text style for small buttons
-    public val smallTextStyle: TextStyle @Composable get() = LabTheme.typography.labelLarge.copy(color = Color.Unspecified)
+    // Text style for small buttons used to be different so we have a separate default here atm
+    public val smallTextStyle: TextStyle @Composable get() = textStyle
 
     @Composable
     public fun buttonBorder(): LabButtonBorder {

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabFilledButton.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabFilledButton.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mobi.lab.components.compose.theme.LabTheme
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.previewInteractionSourceOf
@@ -27,8 +26,6 @@ import mobi.lab.components.compose.widget.image.ImageSource
 @Composable
 public fun LabFilledButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.minWidth,
-    minHeight: Dp = LabButtonDefaults.minHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -55,8 +52,6 @@ public fun LabFilledButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -77,8 +72,6 @@ public fun LabFilledButton(
 @Composable
 public fun LabFilledSmallButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.smallMinWidth,
-    minHeight: Dp = LabButtonDefaults.smallMinHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -105,8 +98,6 @@ public fun LabFilledSmallButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -214,19 +205,6 @@ private fun PreviewLightDifferentFont() {
 
 @Preview(showBackground = true)
 @Composable
-private fun PreviewLightDifferentSize() {
-    PreviewContainer {
-        LabFilledButton(
-            text = "M Size different",
-            onClick = {},
-            minWidth = 60.dp,
-            minHeight = 60.dp,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
 private fun PreviewLightEnabledLoading() {
     PreviewContainer {
         LabFilledButton(
@@ -308,20 +286,6 @@ private fun PreviewSmallLightDifferentFont() {
         LabFilledSmallButton(
             text = "S Font different",
             onClick = {},
-            textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PreviewSmallLightDifferentSize() {
-    PreviewContainer {
-        LabFilledSmallButton(
-            text = "S Size different",
-            onClick = {},
-            minWidth = 28.dp,
-            minHeight = 28.dp,
             textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
         )
     }

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabIconButton.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabIconButton.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.previewInteractionSourceOf
 import mobi.lab.components.compose.widget.button.LabButtonDefaults.DefaultButtonProgressIndicator
@@ -24,11 +23,9 @@ import mobi.lab.components.compose.widget.image.ImageSource
 @Composable
 public fun LabIconButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.minWidth,
-    minHeight: Dp = LabButtonDefaults.minHeight,
     icon: ImageSource,
     contentDescription: String,
-    iconSize: Dp = LabButtonDefaults.iconSize,
+    iconSize: Dp = LabButtonDefaults.iconButtonIconSize,
     onClick: () -> Unit,
     enabled: Boolean = true,
     showProgress: Boolean = false,
@@ -45,8 +42,6 @@ public fun LabIconButton(
     LabButton(
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = icon,
         iconStartContentDescription = contentDescription,
         iconSize = iconSize,
@@ -65,11 +60,9 @@ public fun LabIconButton(
 @Composable
 public fun LabIconSmallButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.smallMinWidth,
-    minHeight: Dp = LabButtonDefaults.smallMinHeight,
     icon: ImageSource,
     contentDescription: String,
-    iconSize: Dp = LabButtonDefaults.smallIconSize,
+    iconSize: Dp = LabButtonDefaults.iconButtonSmallIconSize,
     onClick: () -> Unit,
     enabled: Boolean = true,
     showProgress: Boolean = false,
@@ -86,8 +79,6 @@ public fun LabIconSmallButton(
     LabSmallButton(
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = icon,
         iconStartContentDescription = contentDescription,
         iconSize = iconSize,
@@ -228,21 +219,6 @@ private fun PreviewLightDisabled() {
 
 @Preview(showBackground = true)
 @Composable
-private fun PreviewLightSizeDifferent() {
-    PreviewContainer {
-        LabIconButton(
-            icon = ImageSource.vector(Icons.Filled.FavoriteBorder),
-            contentDescription = "Like",
-            onClick = {},
-            enabled = false,
-            minWidth = 60.dp,
-            minHeight = 60.dp,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
 private fun PreviewSmallLightDisabled() {
     PreviewContainer {
         LabIconSmallButton(
@@ -250,21 +226,6 @@ private fun PreviewSmallLightDisabled() {
             contentDescription = "Like",
             onClick = {},
             enabled = false
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PreviewSmallLightDifferentSize() {
-    PreviewContainer {
-        LabIconSmallButton(
-            icon = ImageSource.vector(Icons.Filled.FavoriteBorder),
-            contentDescription = "Like",
-            onClick = {},
-            enabled = false,
-            minWidth = 28.dp,
-            minHeight = 28.dp,
         )
     }
 }

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabOutlinedButton.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabOutlinedButton.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mobi.lab.components.compose.theme.LabTheme
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.previewInteractionSourceOf
@@ -27,8 +26,6 @@ import mobi.lab.components.compose.widget.image.ImageSource
 @Composable
 public fun LabOutlinedButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.minWidth,
-    minHeight: Dp = LabButtonDefaults.minHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -55,8 +52,6 @@ public fun LabOutlinedButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -77,8 +72,6 @@ public fun LabOutlinedButton(
 @Composable
 public fun LabOutlinedSmallButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.smallMinWidth,
-    minHeight: Dp = LabButtonDefaults.smallMinHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -105,8 +98,6 @@ public fun LabOutlinedSmallButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -311,8 +302,6 @@ private fun PreviewLightDifferentSize() {
         LabOutlinedButton(
             text = "M Size different",
             onClick = {},
-            minWidth = 60.dp,
-            minHeight = 60.dp,
         )
     }
 }
@@ -348,8 +337,6 @@ private fun PreviewSmallLightDifferentSize() {
         LabOutlinedSmallButton(
             text = "S Size different",
             onClick = {},
-            minWidth = 28.dp,
-            minHeight = 28.dp,
             textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
         )
     }

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabTextButton.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabTextButton.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mobi.lab.components.compose.theme.LabTheme
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.previewInteractionSourceOf
@@ -25,8 +24,6 @@ import mobi.lab.components.compose.widget.image.ImageSource
 @Composable
 public fun LabTextButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.minWidth,
-    minHeight: Dp = LabButtonDefaults.minHeight,
     text: String,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -53,8 +50,6 @@ public fun LabTextButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -75,8 +70,6 @@ public fun LabTextButton(
 @Composable
 public fun LabTextSmallButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.smallMinWidth,
-    minHeight: Dp = LabButtonDefaults.smallMinHeight,
     text: String,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -103,8 +96,6 @@ public fun LabTextSmallButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -229,8 +220,6 @@ private fun PreviewLightDifferentSize() {
         LabTextButton(
             text = "M Size different",
             onClick = {},
-            minWidth = 60.dp,
-            minHeight = 60.dp,
         )
     }
 }
@@ -266,8 +255,6 @@ private fun PreviewSmallLightDifferentSize() {
         LabTextSmallButton(
             text = "S Size different",
             onClick = {},
-            minWidth = 28.dp,
-            minHeight = 28.dp,
             textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
         )
     }

--- a/lib/src/main/java/mobi/lab/components/compose/widget/button/LabTonedButton.kt
+++ b/lib/src/main/java/mobi/lab/components/compose/widget/button/LabTonedButton.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mobi.lab.components.compose.theme.LabTheme
 import mobi.lab.components.compose.util.PreviewContainer
 import mobi.lab.components.compose.util.previewInteractionSourceOf
@@ -27,8 +26,6 @@ import mobi.lab.components.compose.widget.image.ImageSource
 @Composable
 public fun LabTonedButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.minWidth,
-    minHeight: Dp = LabButtonDefaults.minHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -55,8 +52,6 @@ public fun LabTonedButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -77,8 +72,6 @@ public fun LabTonedButton(
 @Composable
 public fun LabTonedSmallButton(
     modifier: Modifier = Modifier,
-    minWidth: Dp = LabButtonDefaults.smallMinWidth,
-    minHeight: Dp = LabButtonDefaults.smallMinHeight,
     text: String? = null,
     onClick: () -> Unit,
     iconStart: ImageSource? = null,
@@ -105,8 +98,6 @@ public fun LabTonedSmallButton(
         text = text,
         onClick = onClick,
         modifier = modifier,
-        minWidth = minWidth,
-        minHeight = minHeight,
         iconStart = iconStart,
         iconEnd = iconEnd,
         iconSize = iconSize,
@@ -219,8 +210,6 @@ private fun PreviewLightDifferentSize() {
         LabTonedButton(
             text = "M Size different",
             onClick = {},
-            minWidth = 60.dp,
-            minHeight = 60.dp,
         )
     }
 }
@@ -320,8 +309,6 @@ private fun PreviewSmallLightDifferentSize() {
         LabTonedSmallButton(
             text = "S Size different",
             onClick = {},
-            minWidth = 28.dp,
-            minHeight = 28.dp,
             textStyle = LabTheme.typography.labelSmall.copy(color = Color.Unspecified)
         )
     }


### PR DESCRIPTION
# Changes
- Change the medium size button (Filled, Tonal, Outlined and Text buttons) text style token from body-large→label-large
- Change the medium size (Filled, Tonal, Outlined and Text) button leading and trailing icon (+loader) sizes from 24px→20px.
- Move  button minHeight and minWidth to theme so engineers can use them to handle lineHeigh on platforms

